### PR TITLE
Recipe template, Issue #4

### DIFF
--- a/recipe.css
+++ b/recipe.css
@@ -1,0 +1,9 @@
+.cb-main-container {
+  max-width: 650px;
+  margin: 0 auto;
+}
+
+.cb-table-container {
+  max-width: 400px;
+  margin: 0 auto;
+}

--- a/recipe.html
+++ b/recipe.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cook Book</title>
+    <!-- <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous" /> -->
+    <link
+      rel="stylesheet"
+      href="https://bootswatch.com/4/minty/bootstrap.min.css"
+    />
+    <link rel="stylesheet" href="recipe.css" />
+  </head>
+
+  <body>
+    <!-- NAV BAR -->
+    <nav class="navbar sticky-top navbar-expand-sm navbar-dark bg-primary">
+      <div class="container">
+        <a class="navbar-brand" href="#">Recipify</a>
+        <button
+          class="navbar-toggler"
+          type="button"
+          data-toggle="collapse"
+          data-target="#navbarColor01"
+          aria-controls="navbarColor01"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+        >
+          <span class="navbar-toggler-icon"></span>
+        </button>
+
+        <div class="collapse navbar-collapse" id="navbarColor01">
+          <ul class="navbar-nav ml-auto">
+            <li class="nav-item active">
+              <a class="nav-link" href="#antipasto">Antipasto</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="#primo">Primo</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="#secondo">Secondo</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="#dolce">Dolce</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+    <main class="cb-main-container py-5 px-4">
+      <!-- TAG, TITLE & DESCRIPTION -->
+      <div class="badge badge-pill badge-secondary">Category</div>
+      <h1 class="text-primary">
+        Recipe Name
+      </h1>
+      <div class="blockquote">
+        <p class="mb-0">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer
+          posuere erat a ante.
+        </p>
+      </div>
+
+      <!-- MAIN IMAGE -->
+      <img
+        src="https://picsum.photos/1000/700"
+        alt="Recipe Name Image"
+        class="img-fluid mb-4"
+      />
+
+      <!-- LIST OF INGREDIENTS -->
+      <div class="cb-table-container mb-4">
+        <ul class="list-group">
+          <li
+            class="list-group-item d-flex justify-content-between align-items-center"
+          >
+            Ingredient One
+            <span class="badge badge-primary badge-pill">2 cups</span>
+          </li>
+          <li
+            class="list-group-item d-flex justify-content-between align-items-center"
+          >
+            Ingredient Two
+            <span class="badge badge-primary badge-pill">1 spoon</span>
+          </li>
+          <li
+            class="list-group-item d-flex justify-content-between align-items-center"
+          >
+            Ingredient Three
+            <span class="badge badge-primary badge-pill">3</span>
+          </li>
+        </ul>
+      </div>
+
+      <!-- INSTRUCTIONS -->
+      <p>
+        I love cheese, especially blue castello ricotta. Ricotta caerphilly
+        caerphilly fromage frais pecorino cheeseburger say cheese st. agur blue
+        cheese. Cream cheese fromage frais queso fromage fondue croque monsieur
+        camembert de normandie fromage. Cow smelly cheese paneer roquefort feta
+        lancashire taleggio pepper jack. Cheese triangles parmesan cow croque
+        monsieur halloumi cheese strings cream cheese cow. Camembert de
+        normandie monterey jack gouda queso melted cheese.
+      </p>
+      <p>
+        Cheeseburger who moved my cheese dolcelatte. Who moved my cheese
+        emmental cheesy feet cheese slices melted cheese stinking bishop brie
+        cheesecake. Rubber cheese mozzarella manchego cheesy grin queso cheese
+        slices stinking bishop monterey jack. Mozzarella pecorino st. agur blue
+        cheese the big cheese cheesy grin brie cheese on toast the big cheese.
+        Pepper jack stinking bishop caerphilly the big cheese dolcelatte ricotta
+        cottage cheese babybel. Emmental ricotta pepper jack cheesy feet
+        everyone loves fromage cheese triangles port-salut. Brie stinking bishop
+        cheddar dolcelatte gouda cream cheese parmesan stinking bishop. Cheesy
+        feet goat squirty cheese queso fromage frais melted cheese cauliflower
+        cheese.
+      </p>
+      <p>
+        Cheese slices mozzarella dolcelatte. Brie danish fontina fondue fondue
+        when the cheese comes out everybody's happy cheesecake the big cheese
+        dolcelatte. Monterey jack fromage frais st. agur blue cheese pepper jack
+        lancashire mozzarella pepper jack cauliflower cheese. Cow stilton cheese
+        triangles ricotta cheesy feet pecorino fromage airedale. Halloumi
+        macaroni cheese paneer bavarian bergkase say cheese feta bavarian
+        bergkase queso. Smelly cheese boursin port-salut cheese and biscuits.
+      </p>
+      <p>
+        St. agur blue cheese squirty cheese cauliflower cheese. Mozzarella blue
+        castello hard cheese boursin cheese and biscuits melted cheese danish
+        fontina melted cheese. Cauliflower cheese macaroni cheese fromage
+        pecorino swiss parmesan cheesecake cheese slices. Mozzarella cheese
+        strings paneer halloumi st. agur blue cheese pecorino cauliflower cheese
+        mozzarella. Queso taleggio fromage st. agur blue cheese emmental blue
+        castello taleggio mascarpone. Cheese on toast cheesy feet croque
+        monsieur queso mozzarella cheese on toast smelly cheese pepper jack.
+        Danish fontina caerphilly squirty cheese cheesy grin bocconcini cheese
+        triangles taleggio roquefort. Hard cheese feta emmental.
+      </p>
+      <p>
+        Cheese slices caerphilly taleggio. Cheddar swiss brie cheese on toast
+        roquefort dolcelatte cheddar red leicester. Boursin cheesy grin
+        cheesecake bocconcini croque monsieur swiss blue castello cottage
+        cheese. Camembert de normandie pepper jack smelly cheese cheesy grin
+        airedale feta bocconcini ricotta. Paneer bocconcini babybel stinking
+        bishop ricotta cheese and wine queso taleggio. Monterey jack fromage
+        caerphilly.
+      </p>
+    </main>
+
+    <footer class="navbar navbar-dark bg-dark text-white py-4">
+      <div class="container">
+        <small class="col text-right">
+          Group 2: Bruno, Ourania, Joss
+        </small>
+      </div>
+    </footer>
+    <script
+      src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+      integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
+      integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js"
+      integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI"
+      crossorigin="anonymous"
+    ></script>
+  </body>
+</html>

--- a/recipe.html
+++ b/recipe.html
@@ -50,101 +50,29 @@
 
     <main class="cb-main-container py-5 px-4">
       <!-- TAG, TITLE & DESCRIPTION -->
-      <div class="badge badge-pill badge-secondary">Category</div>
-      <h1 class="text-primary">
+      <div id="el-tag" class="badge badge-pill badge-secondary"></div>
+      <h1 id="el-headline" class="text-primary">
         Recipe Name
       </h1>
       <div class="blockquote">
-        <p class="mb-0">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer
-          posuere erat a ante.
-        </p>
+        <p id="el-description" class="mb-0"></p>
       </div>
 
       <!-- MAIN IMAGE -->
       <img
+        id="el-image"
         src="https://picsum.photos/1000/700"
         alt="Recipe Name Image"
-        class="img-fluid mb-4"
+        class="img-fluid mb-4 rounded"
       />
 
       <!-- LIST OF INGREDIENTS -->
       <div class="cb-table-container mb-4">
-        <ul class="list-group">
-          <li
-            class="list-group-item d-flex justify-content-between align-items-center"
-          >
-            Ingredient One
-            <span class="badge badge-primary badge-pill">2 cups</span>
-          </li>
-          <li
-            class="list-group-item d-flex justify-content-between align-items-center"
-          >
-            Ingredient Two
-            <span class="badge badge-primary badge-pill">1 spoon</span>
-          </li>
-          <li
-            class="list-group-item d-flex justify-content-between align-items-center"
-          >
-            Ingredient Three
-            <span class="badge badge-primary badge-pill">3</span>
-          </li>
-        </ul>
+        <ul id="el-ingredients" class="list-group"></ul>
       </div>
 
       <!-- INSTRUCTIONS -->
-      <p>
-        I love cheese, especially blue castello ricotta. Ricotta caerphilly
-        caerphilly fromage frais pecorino cheeseburger say cheese st. agur blue
-        cheese. Cream cheese fromage frais queso fromage fondue croque monsieur
-        camembert de normandie fromage. Cow smelly cheese paneer roquefort feta
-        lancashire taleggio pepper jack. Cheese triangles parmesan cow croque
-        monsieur halloumi cheese strings cream cheese cow. Camembert de
-        normandie monterey jack gouda queso melted cheese.
-      </p>
-      <p>
-        Cheeseburger who moved my cheese dolcelatte. Who moved my cheese
-        emmental cheesy feet cheese slices melted cheese stinking bishop brie
-        cheesecake. Rubber cheese mozzarella manchego cheesy grin queso cheese
-        slices stinking bishop monterey jack. Mozzarella pecorino st. agur blue
-        cheese the big cheese cheesy grin brie cheese on toast the big cheese.
-        Pepper jack stinking bishop caerphilly the big cheese dolcelatte ricotta
-        cottage cheese babybel. Emmental ricotta pepper jack cheesy feet
-        everyone loves fromage cheese triangles port-salut. Brie stinking bishop
-        cheddar dolcelatte gouda cream cheese parmesan stinking bishop. Cheesy
-        feet goat squirty cheese queso fromage frais melted cheese cauliflower
-        cheese.
-      </p>
-      <p>
-        Cheese slices mozzarella dolcelatte. Brie danish fontina fondue fondue
-        when the cheese comes out everybody's happy cheesecake the big cheese
-        dolcelatte. Monterey jack fromage frais st. agur blue cheese pepper jack
-        lancashire mozzarella pepper jack cauliflower cheese. Cow stilton cheese
-        triangles ricotta cheesy feet pecorino fromage airedale. Halloumi
-        macaroni cheese paneer bavarian bergkase say cheese feta bavarian
-        bergkase queso. Smelly cheese boursin port-salut cheese and biscuits.
-      </p>
-      <p>
-        St. agur blue cheese squirty cheese cauliflower cheese. Mozzarella blue
-        castello hard cheese boursin cheese and biscuits melted cheese danish
-        fontina melted cheese. Cauliflower cheese macaroni cheese fromage
-        pecorino swiss parmesan cheesecake cheese slices. Mozzarella cheese
-        strings paneer halloumi st. agur blue cheese pecorino cauliflower cheese
-        mozzarella. Queso taleggio fromage st. agur blue cheese emmental blue
-        castello taleggio mascarpone. Cheese on toast cheesy feet croque
-        monsieur queso mozzarella cheese on toast smelly cheese pepper jack.
-        Danish fontina caerphilly squirty cheese cheesy grin bocconcini cheese
-        triangles taleggio roquefort. Hard cheese feta emmental.
-      </p>
-      <p>
-        Cheese slices caerphilly taleggio. Cheddar swiss brie cheese on toast
-        roquefort dolcelatte cheddar red leicester. Boursin cheesy grin
-        cheesecake bocconcini croque monsieur swiss blue castello cottage
-        cheese. Camembert de normandie pepper jack smelly cheese cheesy grin
-        airedale feta bocconcini ricotta. Paneer bocconcini babybel stinking
-        bishop ricotta cheese and wine queso taleggio. Monterey jack fromage
-        caerphilly.
-      </p>
+      <div id="el-instructions"></div>
     </main>
 
     <footer class="navbar navbar-dark bg-dark text-white py-4">
@@ -169,5 +97,6 @@
       integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI"
       crossorigin="anonymous"
     ></script>
+    <script src="recipe.js"></script>
   </body>
 </html>

--- a/recipe.js
+++ b/recipe.js
@@ -135,7 +135,7 @@ if (recipe) {
 
     // Create another element for the amount & apply classes
     const elAmount = document.createElement('span');
-    elAmount.className = 'badge badge-primary badge-pill';
+    elAmount.className = 'badge badge-secondary badge-pill';
 
     // Since the amount is nested inside of the ingredient element, we first
     // set the innerHTML of the amount

--- a/recipe.js
+++ b/recipe.js
@@ -1,0 +1,159 @@
+// Recipe data that gets displayed on the page
+const recipes = [
+  {
+    slug: 'tiramisu',
+    title: 'Tiramisu',
+    category: 'Dolce',
+    description:
+      'I love cheese, especially macaroni cheese babybel. Lancashire who moved my cheese cheddar the big cheese the big cheese cheeseburger jarlsberg parmesan.',
+    image: 'https://picsum.photos/1000/700',
+    ingredients: [
+      ['Ingredient One', '3 cups'],
+      ['Ingredient Two', '2 spoons'],
+      ['Cheese', 'all of it, obvs']
+    ],
+    instructions: `<p>
+      I love cheese, especially blue castello ricotta. Ricotta caerphilly
+      caerphilly fromage frais pecorino cheeseburger say cheese st. agur blue
+      cheese. Cream cheese fromage frais queso fromage fondue croque monsieur
+      camembert de normandie fromage. Cow smelly cheese paneer roquefort feta
+      lancashire taleggio pepper jack. Cheese triangles parmesan cow croque
+      monsieur halloumi cheese strings cream cheese cow. Camembert de
+      normandie monterey jack gouda queso melted cheese.
+    </p>
+    <p>
+      Cheeseburger who moved my cheese dolcelatte. Who moved my cheese
+      emmental cheesy feet cheese slices melted cheese stinking bishop brie
+      cheesecake. Rubber cheese mozzarella manchego cheesy grin queso cheese
+      slices stinking bishop monterey jack. Mozzarella pecorino st. agur blue
+      cheese the big cheese cheesy grin brie cheese on toast the big cheese.
+      Pepper jack stinking bishop caerphilly the big cheese dolcelatte ricotta
+      cottage cheese babybel. Emmental ricotta pepper jack cheesy feet
+      everyone loves fromage cheese triangles port-salut. Brie stinking bishop
+      cheddar dolcelatte gouda cream cheese parmesan stinking bishop. Cheesy
+      feet goat squirty cheese queso fromage frais melted cheese cauliflower
+      cheese.
+    </p>
+    <p>
+      Cheese slices mozzarella dolcelatte. Brie danish fontina fondue fondue
+      when the cheese comes out everybody's happy cheesecake the big cheese
+      dolcelatte. Monterey jack fromage frais st. agur blue cheese pepper jack
+      lancashire mozzarella pepper jack cauliflower cheese. Cow stilton cheese
+      triangles ricotta cheesy feet pecorino fromage airedale. Halloumi
+      macaroni cheese paneer bavarian bergkase say cheese feta bavarian
+      bergkase queso. Smelly cheese boursin port-salut cheese and biscuits.
+    </p>
+    <p>
+      St. agur blue cheese squirty cheese cauliflower cheese. Mozzarella blue
+      castello hard cheese boursin cheese and biscuits melted cheese danish
+      fontina melted cheese. Cauliflower cheese macaroni cheese fromage
+      pecorino swiss parmesan cheesecake cheese slices. Mozzarella cheese
+      strings paneer halloumi st. agur blue cheese pecorino cauliflower cheese
+      mozzarella. Queso taleggio fromage st. agur blue cheese emmental blue
+      castello taleggio mascarpone. Cheese on toast cheesy feet croque
+      monsieur queso mozzarella cheese on toast smelly cheese pepper jack.
+      Danish fontina caerphilly squirty cheese cheesy grin bocconcini cheese
+      triangles taleggio roquefort. Hard cheese feta emmental.
+    </p>
+    <p>
+      Cheese slices caerphilly taleggio. Cheddar swiss brie cheese on toast
+      roquefort dolcelatte cheddar red leicester. Boursin cheesy grin
+      cheesecake bocconcini croque monsieur swiss blue castello cottage
+      cheese. Camembert de normandie pepper jack smelly cheese cheesy grin
+      airedale feta bocconcini ricotta. Paneer bocconcini babybel stinking
+      bishop ricotta cheese and wine queso taleggio. Monterey jack fromage
+      caerphilly.
+    </p>`
+  },
+  {
+    slug: 'caprese',
+    title: 'Mozzarella Caprese',
+    category: 'Antipasto',
+    image: 'https://picsum.photos/1000/700',
+    description:
+      'I love cheese, especially pepper jack ricotta. Pecorino feta cheese on toast cow edam who moved my cheese goat camembert de normandie.',
+    ingredients: [
+      ['Ingredient One', '34 cups'],
+      ['Ingredient Two', '212 spoons'],
+      ['Mozarella', '2 planets'],
+      ['Cheese', 'all of it, obvs']
+    ],
+    instructions: `<p>
+    I love cheese, especially dolcelatte melted cheese. Macaroni cheese cheeseburger st. agur blue cheese edam cheese and biscuits boursin parmesan cheeseburger. Pecorino ricotta when the cheese comes out everybody's happy chalk and cheese fondue port-salut babybel cow. Cheesy grin everyone loves gouda cow bavarian bergkase chalk and cheese camembert de normandie who moved my cheese. Mozzarella fromage cheese triangles mascarpone.
+    </p>
+    <p>
+    Everyone loves lancashire queso. Fromage when the cheese comes out everybody's happy feta ricotta say cheese cheddar stinking bishop mozzarella. Brie dolcelatte croque monsieur manchego cheese on toast cheese strings cauliflower cheese cottage cheese. Cheese strings pepper jack st. agur blue cheese.
+    </p>
+    <p>
+    Queso goat parmesan. Cheese slices boursin mascarpone fromage frais parmesan smelly cheese babybel when the cheese comes out everybody's happy. Bocconcini pepper jack cheese slices airedale cut the cheese squirty cheese cut the cheese airedale. Ricotta babybel fondue emmental.
+    </p>
+    <p>
+    Brie dolcelatte babybel. The big cheese gouda gouda melted cheese halloumi pecorino parmesan cream cheese. Roquefort cheeseburger everyone loves bavarian bergkase fondue cheese on toast who moved my cheese cheesecake. Jarlsberg cheese triangles jarlsberg babybel blue castello feta halloumi.
+    </p>`
+  }
+];
+
+// Fetching the recipe-query from the URL (`recipe=[something]`)
+const params = new URL(document.location).searchParams;
+const query = params.get('recipe'); // for `recipe.html?recipe=tiramisu`, this variable would now be 'tiramisu'
+
+// Defining all the page elements that need to change
+// (By applying `id="el-something"`, we can select them in JS with getElementById)
+const elTag = document.getElementById('el-tag');
+const elHeadline = document.getElementById('el-headline');
+const elDescription = document.getElementById('el-description');
+const elImage = document.getElementById('el-image');
+const elIngredients = document.getElementById('el-ingredients');
+const elInstructions = document.getElementById('el-instructions');
+
+// We look through the data array to get the recipe data we need
+const recipe = recipes.filter((item) => item.slug == query)[0];
+
+// Before applying all the data to the page, we need to check if the query query actually relates to something in our data
+// If it does, we keep going
+if (recipe) {
+  // First we set all the simple elements
+  // ('Simple' meaning elements that only need to have their inner text set to the correct value)
+  elTag.innerHTML = recipe.category;
+  elHeadline.innerHTML = recipe.title;
+  elDescription.innerHTML = recipe.description;
+  elInstructions.innerHTML = recipe.instructions;
+
+  // For the image, we need to set the src-attribute instead of innerHTML
+  // And also the alt-text
+  elImage.setAttribute('src', recipe.image);
+  elImage.setAttribute('alt', recipe.title);
+
+  // Finally, we need to generate the ingredients list
+  // First we define a function that appends a list item to the list on the page.
+  // As arguments, it needs an ingredient description and the amount
+  function generateIngredientItem(ingredient, amount) {
+    // Create the element & apply the necessary classes
+    const elIngredient = document.createElement('li');
+    elIngredient.className =
+      'list-group-item d-flex justify-content-between align-items-center';
+
+    // Create another element for the amount & apply classes
+    const elAmount = document.createElement('span');
+    elAmount.className = 'badge badge-primary badge-pill';
+
+    // Since the amount is nested inside of the ingredient element, we first
+    // set the innerHTML of the amount
+    elAmount.innerHTML = amount;
+
+    // Next, we set the innerHTML of the ingredient element and append the amount element
+    elIngredient.innerHTML = ingredient;
+    elIngredient.appendChild(elAmount);
+
+    // Finally, we append the created element to the ingredients list on the page
+    elIngredients.appendChild(elIngredient);
+  }
+
+  // Now, we iterate through the array of ingredients and call our function for each of them
+  recipe.ingredients.forEach((tuple) =>
+    generateIngredientItem(tuple[0], tuple[1])
+  );
+} else {
+  // This code block will run, if the param in the URL isn't found on the recipe data array
+  elHeadline.innerHTML = 'Error 404: Page not found :(';
+}


### PR DESCRIPTION
This adds a `recipe.html` to the code base, as well as some associated JS- and CSS-files. It allows us to only have one html-file for recipes instead of a seperate one for each recipe. Recipes can be linked to by using the URL `recipe.html?recipe=tiramisu` (for example). 

To add recipes, you can have a look in the `recipe.js`-file and follow the structure of the array at the top.

There is also fallback for the case that no parameter is provided as well as the case that the parameter doesn't exist in our data. In both cases, the page will display 'Error 404: Page not found :('.